### PR TITLE
Allow async publish.once functions, and fix name reference in error message

### DIFF
--- a/lib/ddp.js
+++ b/lib/ddp.js
@@ -40,7 +40,7 @@ Meteor.connection._processOneDataMessage = function (msg, updates) {
   }
 
   const ignore = (messageType === 'added' && serverDoc?.document?._id)
-    || (messageType === 'removed' && existingDoc && activeSub && existingDoc.__sub === activeSub.handle.subscriptionId)
+    || (messageType === 'removed' && existingDoc && activeSub && existingDoc.__sub === activeSub.handle.subscriptionId && !msg.deletedFromDatabase)
     || (!existingDoc && (messageType === 'changed' || messageType === 'removed' && !serverDoc?.document));
 
   if (hasActiveRegSub) { // sub may have been added if you have a regular publication and a .once publication on the same collection and you're navigating between them. if that's the case, we want to remove the sub when the subscription from regular publication becomes the active one.

--- a/lib/ddp.js
+++ b/lib/ddp.js
@@ -44,7 +44,7 @@ Meteor.connection._processOneDataMessage = function (msg, updates) {
     || (!existingDoc && (messageType === 'changed' || messageType === 'removed' && !serverDoc?.document));
 
   if (hasActiveRegSub && existingDoc) { // sub may have been added if you have a regular publication and a .once publication on the same collection and you're navigating between them. if that's the case, we want to remove the sub when the subscription from regular publication becomes the active one.
-    existingDoc.__subs = existingDoc.__subs?.filter(subId => subId != activeSub.handle.subscriptionId);
+    // Don't do anything here becuase the active sub may not be for *this* document.
   }
 
   if (ignore) {

--- a/lib/ddp.js
+++ b/lib/ddp.js
@@ -34,17 +34,17 @@ Meteor.connection._processOneDataMessage = function (msg, updates) {
   // keep track of added ids when using publish.once so that we can clean them up with removeFromMiniMongo
   if (messageType === 'added') {
     if (!hasActiveRegSub && activeSub) {
-      msg.fields.__sub = activeSub.handle.subscriptionId
+      msg.fields.__subs = [activeSub.handle.subscriptionId];
       this._pushUpdate(updates, msg.collection, msg); // _pushUpdate is internal to _processOneDataMessageOriginal but it wasn't being executed by the logic in there so we had to add it here. I think it would probably be preferable to return early here as an optimization but leaving as is for now.
     }
   }
 
   const ignore = (messageType === 'added' && serverDoc?.document?._id)
-    || (messageType === 'removed' && existingDoc && activeSub && existingDoc.__sub === activeSub.handle.subscriptionId && !msg.deletedFromDatabase)
+    || (messageType === 'removed' && existingDoc && activeSub && existingDoc.__subs?.includes(activeSub.handle.subscriptionId) && !msg.deletedFromDatabase)
     || (!existingDoc && (messageType === 'changed' || messageType === 'removed' && !serverDoc?.document));
 
-  if (hasActiveRegSub) { // sub may have been added if you have a regular publication and a .once publication on the same collection and you're navigating between them. if that's the case, we want to remove the sub when the subscription from regular publication becomes the active one.
-    delete existingDoc?.__sub
+  if (hasActiveRegSub && existingDoc) { // sub may have been added if you have a regular publication and a .once publication on the same collection and you're navigating between them. if that's the case, we want to remove the sub when the subscription from regular publication becomes the active one.
+    existingDoc.__subs = existingDoc.__subs?.filter(subId => subId != activeSub.handle.subscriptionId);
   }
 
   if (ignore) {

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -55,16 +55,18 @@ Mongo.Collection.prototype.removeAsync = async function (selector) {
   const docIdsToBeRemoved = extractedIds?.length ? extractedIds : await this.find(filter, { fields: { _id: 1 }}).mapAsync(doc => doc._id);
   const numRemoved = await originalRemove.call(this, filter);
 
+  // Add an extra deletedFromDatabase parameter so in the patch of Meteor._processOneDataMessage
+  // the removed messages are not ignored.
   if (docIdsToBeRemoved.length === numRemoved) {
     for (const id of docIdsToBeRemoved) {
-      session.send({ msg: 'removed', id: MongoID.idStringify(id), collection: this._name })
+      session.send({ msg: 'removed', id: MongoID.idStringify(id), collection: this._name, deletedFromDatabase: true })
     }
   } else if (numRemoved > 0) {
     // if some of the documents failed to remove, then only send 'removed' for the ones that were successfully removed
     const docIdsRemaining = new Set(await this.find(filter, { fields: { _id: 1 }}).map(doc => doc._id));
     for (const id of docIdsToBeRemoved) {
       if (!docIdsRemaining.has(id)) {
-        session.send({ msg: 'removed', id: MongoID.idStringify(id), collection: this._name });
+        session.send({ msg: 'removed', id: MongoID.idStringify(id), collection: this._name, deletedFromDatabase: true });
       }
     }
   }

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -96,7 +96,7 @@ Mongo.Collection.prototype.updateAsync = async function (selector, modifier, opt
 
   const modifierKeys = Object.keys(modifier);
   const isReplace = !isUpsertOrMulti && modifierKeys.every(k => !k.includes('$'));
-  const result = isUpsertOrMulti ? await originalUpdate.call(this, filter, modifier, options) : isReplace ? await rawCollection.findOneAndReplace(filter, modifier, {...options, returnDocument: 'after'}) : await rawCollection.findOneAndUpdate(filter, modifier, {...options, returnDocument: 'after'});
+  const result = await originalUpdate.call(this, filter, modifier, options);
 
   const { insertedId, numberAffected, value } = result;
   if (result === 0 || value === null) {
@@ -107,7 +107,7 @@ Mongo.Collection.prototype.updateAsync = async function (selector, modifier, opt
     const fields = isReplace ? modifier : { ...modifier.$set, ...modifier.$setOnInsert };
     session.send({ msg: 'added', id: MongoID.idStringify(insertedId), fields, collection: this._name });
   } else if (!isUpsertOrMulti) {
-    const { _id, ...fields } = value;
+    const { _id, ...fields } = await rawCollection.findOne(filter);
     session.send({ msg: 'changed', id: MongoID.idStringify(_id), fields, collection: this._name });
   } else {
     const finalFilter = hasId ? filter : insertedId ? { _id: insertedId } : docIds ? {_id: numberAffected === 1 ? docIds[0] : {$in: docIds }} : undefined;

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -17,14 +17,14 @@ function addPublicationName(name, type) {
 // self is the publication context when using .stream and the method context when using .once
 async function fetchData(self, handler, args) {
   const result = {};
-  const handlerReturn = handler.apply(self, args);
+  const handlerReturn = await handler.apply(self, args);
 
   const isSingleCursor = handlerReturn && handlerReturn._publishCursor;
   const isArrayOfCursors = Array.isArray(handlerReturn) && handlerReturn.every(cursor => cursor._publishCursor);
 
   // Validate the cursor(s)
   if (handlerReturn && !isSingleCursor && !isArrayOfCursors) {
-    throw new Error(`Handler for '${name}' returns invalid cursor(s).`);
+    throw new Error(`Handler for '${self.name}' returns invalid cursor(s).`);
   }
 
   if (!isSingleCursor && !isArrayOfCursors) {
@@ -40,7 +40,7 @@ async function fetchData(self, handler, args) {
     const hasDuplicatedCollections = new Set(collectionNames).size !== collectionNames.length;
     // This rule is enforced in the original publish() function
     if (hasDuplicatedCollections)
-      throw new Error(`Handler for '${name}' returns an array containing cursors of the same collection.`);
+      throw new Error(`Handler for '${self.name}' returns an array containing cursors of the same collection.`);
   }
 
   // Fetch the cursor(s)

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -74,7 +74,7 @@ function publishOnce(name, handler) {
   addPublicationName(name, 'once');
 
   Meteor.methods({
-    [name]: async function(...args) {
+    [name]: async function (...args) {
       const customAddedDocuments = [];
 
       overrideLowLevelPublishAPI(this, customAddedDocuments);
@@ -128,9 +128,9 @@ function getChangeStream(collectionName, filter, projection) {
   }
 
   const match = isEmpty(filter) ? {} : { $or: [
-    convertFilter(filter),
-    { 'updateDescription': { '$exists': true } },
-    { 'operationType': 'delete' }
+      convertFilter(filter),
+      { 'updateDescription': { '$exists': true } },
+      { 'operationType': 'delete' }
   ]};
 
   const project = {};
@@ -181,12 +181,12 @@ function stream(name, handler) {
 
   addPublicationName(name, 'stream');
 
-  Meteor.publish(name, async function(...args) {
+  Meteor.publish(name, async function (...args) {
     const stops = [];
 
     const results = await fetchData(this, handler, args);
 
-    for (const [ collectionName, { selector, projection, docs } ] of Object.entries(results)) {
+    for (const [collectionName, { selector, projection, docs }] of Object.entries(results)) {
       for (doc of docs) {
         this.added(collectionName, doc._id, doc);
       }
@@ -213,4 +213,6 @@ function stream(name, handler) {
 }
 
 Meteor.publish.once = publishOnce;
+Meteor.publishOnce = publishOnce;
 Meteor.publish.stream = stream;
+Meteor.publishStream = publishStream;

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -215,4 +215,4 @@ function stream(name, handler) {
 Meteor.publish.once = publishOnce;
 Meteor.publishOnce = publishOnce;
 Meteor.publish.stream = stream;
-Meteor.publishStream = publishStream;
+Meteor.publishStream = stream;

--- a/lib/subscribe.js
+++ b/lib/subscribe.js
@@ -93,8 +93,7 @@ function subscribe(name, ...args) {
       if (cachedIds) {
         Promise.resolve().then(() => { // used to make this run after the .stop is called on the previous handle
           const localCollections = Meteor.connection._mongo_livedata_collections;
-          const modifier = isSimulated ? {$set: {__sub: cachedSubHandle.subscriptionId}} : {$unset: {__sub: ''}};
-
+          const modifier = isSimulated ? {$addToSet: {__subs: cachedSubHandle.subscriptionId}} : {$pull: {__subs: cachedSubHandle.subscriptionId}};
           for (const collectionName of cachedSubHandle._collectionNames) {
             localCollections[collectionName].update({_id: {$in: cachedIds[collectionName]}}, modifier, {multi: true});
           }
@@ -136,7 +135,7 @@ function subscribe(name, ...args) {
           return removeSub(key);
         }, duration);
 
-        const ids = createIdMap(handle._collectionNames, {__sub: {$exists: false}})
+        const ids = createIdMap(handle._collectionNames, {'__subs.0': {$exists: false}})
 
         return updateSub({ key, timeoutId, ids, active: false, refreshedAt: new Date() });
       };
@@ -148,9 +147,21 @@ function subscribe(name, ...args) {
   }
 
   if (!shouldCache) { // when not caching subscriptions, using seen to prevent possible infinite subscription loop. subscribe can fire multiple times very quickly if you aren't careful, most of the time it's harmless but in this case we want to return early
-    const { handle } = seen[key] || {};
+    if (seen[key]) {
+      // Return a fake subscription to the client that has no documents and is immediately ready.
+      // This way, when this subscription ends, we won't remove from Minimongo documents that were
+      // added by the original subscription.
+      const handle = {
+        _isReady: true,
+        _readyDep: new Tracker.Dependency(),
+        stop() {
 
-    if (handle) {
+        },
+        ready() {
+          this._readyDep.depend();
+          return this._isReady;
+        }
+      };
       signalReactiveComputations(handle, onReady);
       return handle;
     }
@@ -179,8 +190,7 @@ function subscribe(name, ...args) {
         removeFromMinimongo(_collectionNames, subscriptionId);
         return removeSub(key);
       }, duration);
-
-      const ids = createIdMap(_collectionNames, {__sub: subscriptionId});
+      const ids = createIdMap(_collectionNames, {__subs: subscriptionId});
 
       return updateSub({ key, timeoutId, ids, active: false, refreshedAt: new Date() });
       /// end minimongo cleanup

--- a/lib/utils/client.js
+++ b/lib/utils/client.js
@@ -78,7 +78,11 @@ export const mergeIntoMinimongo = (data, sub) => {
     for (const doc of docs) {
       const existingDoc = localCollection._docs.get(doc._id);
       const finalDoc = existingDoc ? merge(existingDoc, doc) : doc;
-      finalDoc.__sub = sub;
+      if (!existingDoc || existingDoc.__subs) {
+        // If there's already an existing document from a regular publication (no __subs), 
+        // don't do this, so we don't remove it from Minimongo later.
+        finalDoc.__subs = finalDoc.__subs ? [...new Set([...finalDoc.__subs, sub])] : [sub];
+      }
       existingDoc ? localCollection.update(doc._id, finalDoc) : localCollection.insert(finalDoc);
     }
 
@@ -99,8 +103,8 @@ export const removeFromMinimongo = (collectionNames, sub) => {
     const localCollection = collections[collectionName];
 
     if (!store || !localCollection) continue;
-
-    localCollection.remove({__sub: sub});
+    localCollection.remove({__subs: [sub]});
+    localCollection.update({}, { $pull: { __subs: sub } }, { multi: true });
 
     // Prevent this data from being reset on reconnect
     preventDataReset(store, localCollection);

--- a/lib/utils/client.js
+++ b/lib/utils/client.js
@@ -94,7 +94,7 @@ export const removeFromMinimongo = (collectionNames, sub) => {
   const stores = Meteor.connection._stores;
   const collections = Meteor.connection._mongo_livedata_collections;
 
-  for (const collectionName of collectionNames) {
+  for (const collectionName of collectionNames || []) {
     const store = stores[collectionName];
     const localCollection = collections[collectionName];
 


### PR DESCRIPTION
This PR makes the following changes: 
* Fixes a typo in error messages in `fetchData`.
* Allows the static publication function to be async.
* Adds `Meteor.publishOnce` and `Meteor.publishStream` for compatibility if another package overrides `Meteor.publish`.
* Adds a guard in case `collcetionNames` is empty (which could happen if there's an error in the original publication).
* Removes the use of `rawCollection.findOneAndReplace` and `rawCollection.findOneAndUpdate` to make single-document updates because it could bypass packages that define their own hooks on updates. The tradeoff is an extra `findOne` call to get the document after the update.
* Adds an extra parameter to `removed` DDP messages that are emitted by `removeAsync` so that in `_processOneDataMessage` we can avoid having those DDP messages be ignored by the client (causing the client to retain in Minimongo copies of documents that have been deleted from the database).