### PR TITLE
Fix undefined on pubNames

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -19,7 +19,7 @@ let pubNames = [];
 let streams = [];
 Meteor.startup(() => {
   const all = Meteor.settings.public.packages?.['jam:pub-sub']?.pubs || {};
-  pubNames = Object.values(all)[0];
+  pubNames = Object.values(all)[0] || [];
   streams = all.stream || [];
 });
 


### PR DESCRIPTION
I was getting the following error:
```
W20250411-08:39:11.454(2)? (STDERR) Unhandled promise rejection: TypeError: Cannot read properties of undefined (reading 'some')
W20250411-08:39:11.454(2)? (STDERR)     at shouldSendMutationUpdates (packages/jam:pub-sub/lib/mongo.js:29:19)
W20250411-08:39:11.454(2)? (STDERR)     at ns.Collection.Mongo.Collection.updateAsync (packages/jam:pub-sub/lib/mongo.js:119:8)
W20250411-08:39:11.454(2)? (STDERR)     at ns.Collection.Mongo.Collection.<computed> [as updateAsync] (packages/aldeed:collection2/main.js:256:30)
W20250411-08:39:11.454(2)? (STDERR)     at setAsWatcher (packages/socialize:server-presence/server-presence.js:46:19)
W20250411-08:39:11.454(2)? (STDERR)     at checkForWatcher (packages/socialize:server-presence/server-presence.js:86:5)
W20250411-08:39:11.454(2)? (STDERR)     at processTicksAndRejections (node:internal/process/task_queues:105:5)
```
Made this quick fix to get over it.