### PR TITLE
Fix crash when packages setting does not exist

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -19,7 +19,7 @@ let pubNames = [];
 let streams = [];
 let objectIdCollections = [];
 Meteor.startup(() => {
-  const all = Meteor.settings.public.packages?.['jam:pub-sub']?.pubs || {};
+  const all = Meteor.settings?.public?.packages?.['jam:pub-sub']?.pubs || {};
   pubNames = Object.values(all)[0] || [];
   streams = all.stream || [];
 


### PR DESCRIPTION
Fixes:

I20250525-00:48:19.004(-7)? error on boot.js TypeError: Cannot read properties of undefined (reading 'packages')
I20250525-00:48:19.004(-7)?     at packages/jam:pub-sub/lib/mongo.js:22:38