### PR TITLE
Making publishOnce and stream types consistent?

### DIFF
--- a/pub-sub.d.ts
+++ b/pub-sub.d.ts
@@ -35,7 +35,7 @@ export const config: Config;
  */
 export function configure(options: Partial<Config>): Config;
 
-export declare function publishOnce(name: string, handler: (...args: any[]): { [collectionName: string]: object[] }): void;
+export declare function publishOnce(name: string, handler: (...args: any[]) => void): void;
 export declare function stream(name: string, handler: (...args: any[]) => void): void;
 
 declare module 'meteor/meteor' {

--- a/pub-sub.d.ts
+++ b/pub-sub.d.ts
@@ -35,7 +35,7 @@ export const config: Config;
  */
 export function configure(options: Partial<Config>): Config;
 
-export declare function publishOnce(name: string, handler: (...args: any[]): { [collectionName: string]: object[] };
+export declare function publishOnce(name: string, handler: (...args: any[]): { [collectionName: string]: object[] }): void;
 export declare function stream(name: string, handler: (...args: any[]) => void): void;
 
 declare module 'meteor/meteor' {


### PR DESCRIPTION
I'm not sure if I've done this correctly but I noticed an issue with the `publishOnce` type (seemingly missing a parenthesis) and tried fixing it in slightly contradictory ways (check the commit history). In the end I just made the type consistent with `stream` but I'm not sure that's how it's meant to be, looking at the actual use cases.

Perhaps the `void` I've got there should be an `any`, to make things a bit neater.

```txt
.meteor/local/types/node_modules/package-types/jam_pub-sub/package/web.cordova/pub-sub.d.ts:38:76 - error TS1005: '=>' expected.

38 export declare function publishOnce(name: string, handler: (...args: any[]): { [collectionName: string]: object[] };
                                                                              ~

.meteor/local/types/node_modules/package-types/jam_pub-sub/package/web.cordova/pub-sub.d.ts:38:95 - error TS1005: ']' expected.

38 export declare function publishOnce(name: string, handler: (...args: any[]): { [collectionName: string]: object[] };
                                                                                                 ~

.meteor/local/types/node_modules/package-types/jam_pub-sub/package/web.cordova/pub-sub.d.ts:38:103 - error TS1005: ',' expected.

38 export declare function publishOnce(name: string, handler: (...args: any[]): { [collectionName: string]: object[] };
                                                                                                         ~

.meteor/local/types/node_modules/package-types/jam_pub-sub/package/web.cordova/pub-sub.d.ts:38:104 - error TS1128: Declaration or statement expected.

38 export declare function publishOnce(name: string, handler: (...args: any[]): { [collectionName: string]: object[] };
                                                                                                          ~

.meteor/local/types/node_modules/package-types/jam_pub-sub/package/web.cordova/pub-sub.d.ts:38:113 - error TS1011: An element access expression should take an argument.

38 export declare function publishOnce(name: string, handler: (...args: any[]): { [collectionName: string]: object[] };
                                                                                                                   

.meteor/local/types/node_modules/package-types/jam_pub-sub/package/web.cordova/pub-sub.d.ts:38:115 - error TS1128: Declaration or statement expected.

38 export declare function publishOnce(name: string, handler: (...args: any[]): { [collectionName: string]: object[] };
                                                                                                                     ~
```

Ideally the types would better match the intended usage. Of which there seems to be...

1. void
2. a cursor
3. an array of cursors
